### PR TITLE
preconditions: Leverage the TypeGuard pattern for preconditions

### DIFF
--- a/src/collektions/_iterable.py
+++ b/src/collektions/_iterable.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 __all__ = [
     "associate",
-    "associate_to",
     "associate_by",
     "associate_by_to",
+    "associate_to",
     "associate_with",
     "associate_with_to",
     "average",
@@ -19,11 +19,11 @@ __all__ = [
     "filter_isinstance",
     "filter_not",
     "filter_not_none",
+    "find",
     "first",
     "first_not_none_of",
     "first_not_none_of_or_none",
     "first_or_none",
-    "find",
     "flat_map",
     "flatten",
     "fold",
@@ -37,8 +37,8 @@ __all__ = [
     "is_empty",
     "is_not_empty",
     "map_indexed",
-    "map_not_none",
     "map_indexed_not_none",
+    "map_not_none",
     "max_by",
     "max_of",
     "min_by",
@@ -81,7 +81,6 @@ from collections.abc import (
     Sequence,
 )
 from contextlib import suppress
-from numbers import Real
 from typing import (
     Any,
     Callable,
@@ -168,7 +167,7 @@ def associate_with_to(
     return destination
 
 
-def average(iterable: Iterable[Real]) -> float:
+def average(iterable: Iterable[float | int]) -> float:
     """Return the average (mean) of the values in ``iterable``.
 
     If ``iterable`` has no items, then this function returns ``float("NaN")``,
@@ -178,9 +177,12 @@ def average(iterable: Iterable[Real]) -> float:
     """
 
     sum_ = 0
-    count = 0
+    count: int = 0
     for number in iterable:
-        sum_ += number
+        # Ignore: mypy assignment
+        # Reason: Python will automatically widen int to float if `iterable` is
+        #   `Iterable[float]`, otherwise this will stay an int.
+        sum_ += number  # type: ignore[assignment]
         count += 1
     return sum_ / count if count else float("NaN")
 

--- a/src/collektions/preconditions.py
+++ b/src/collektions/preconditions.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 
 __all__ = ["check", "check_not_none", "require", "require_not_none"]
 
+from typing import Any
+
+from typing_extensions import TypeGuard
 
 from ._types import T
 
@@ -36,10 +39,24 @@ def check(
 def check_not_none(
     value: T | None,
     message: str = "Check failed: value was None.",
-) -> None:
+    exc_type: type[Exception] = RuntimeError,
+) -> TypeGuard[T]:
     """Check that ``value`` is not ``None`` and raise a ``RuntimeError`` if it is."""
-    if value is None:
-        raise RuntimeError(message)
+    if guard := value is None:
+        raise exc_type(message)
+    return guard
+
+
+def check_isinstance(
+    value: Any,
+    type_t: type[T],
+    message: str = "Check failed.",
+    exc_type: type[Exception] = TypeError,
+) -> TypeGuard[T]:
+    """Check that `value` is of type `type_t` or raise `exc_type` with `message`."""
+    if guard := isinstance(value, type_t):
+        raise exc_type(message)
+    return guard
 
 
 def require(
@@ -47,20 +64,23 @@ def require(
     message: str = "Requirement not met.",
     exc_type: type[Exception] = ValueError,
 ) -> None:
-    """Check that the requirement represented by ``condition`` is met.
+    """Require that the requirement represented by ``condition`` is met.
 
     Raises an exception of type ``exc_type`` if the requirement is not met.
 
     By default, ``exc_type`` is :py:obj:`ValueError`.
     """
-    if not condition:
-        e = exc_type(message)
-        raise e
+    check(condition, message, exc_type)
 
 
 def require_not_none(
-    value: T | None, message: str = "Requirement not met: value was None."
-) -> None:
-    """Check that ``value`` is not ``None`` and raise a ``ValueError`` if it is."""
-    if value is None:
-        raise ValueError(message)
+    value: T | None,
+    message: str = "Requirement not met: value was None.",
+    exc_type: type[Exception] = ValueError,
+) -> TypeGuard[T]:
+    """Require that ``value`` is not ``None`` and raise a ``ValueError`` if it is."""
+    return check_not_none(value, message, exc_type)
+
+
+require_isinstance = check_isinstance
+"""Require that `value` is of type `type_t` or raise `exc_type` with `message`."""


### PR DESCRIPTION
For preconditions which can give the caller's type checker insight in to type information for the value argument passed to them use TypeGuard.